### PR TITLE
Use optimizeOptions also for responsive Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ A Strapi plugin that enhances the built-in upload functionality by automatically
 ## New in version 2.1
 You can now pass sharp options for each image format. Check here for available options - https://sharp.pixelplumbing.com/api-output/
 
+## New in version 2.2
+The optimizeSettings are also applied to the generation of responsive images.
+
+Be warned that, if you have booth “optimize images” and “generate responsive images” active in the media library settings the “optimized image“ and not the original will be used to generate the responsive images.
+
 ## Requirements
 
 - Strapi V5.x.x

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.1",
+  "version": "2.2.0",
   "keywords": [
     "strapi",
     "strapi-plugin",


### PR DESCRIPTION
This way one can get nice quality in the responsive images. 
As long as the “optimize images“ setting is not activated. Looks like a strapi oversight to forget the original image in the process.